### PR TITLE
add method to store and retrieve additional parameters from token htt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Archiving this repository: Original angular-oauth2-oidc now does codeflow. Will request to add contextual parameters.
+
 # angular-oauth2-oidc-codeflow
 [![Build Status](https://travis-ci.org/bechhansen/angular-oauth2-oidc.svg?branch=master)](https://travis-ci.org/bechhansen/angular-oauth2-oidc)
 


### PR DESCRIPTION
Add a method to store and retrieve additional parameters contained in the post request.

For example, a SMART on FHIR server may send a 'patient' parameter along with the access token: http://docs.smarthealthit.org/authorization/scopes-and-launch-context/