### PR TITLE
do not redeclare nonce variable, otherwise it will not be attached to the url

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -1093,7 +1093,7 @@ export class OAuthService extends AuthConfig {
 
         let nonce = null;
         if (!this.disableNonceCheck) {
-          let nonce = this.createAndSaveNonce();
+          nonce = this.createAndSaveNonce();
           if (state) {
             state = nonce + this.config.nonceStateSeparator + state;
           } else {


### PR DESCRIPTION
The `nonce` wasn't attached to the login url, as it was redeclared, which got transpiled to 
```js
        var nonce = null;
        if (!this.disableNonceCheck) {
            nonce_1 = this.createAndSaveNonce();
            if (state) {
                state = nonce_1 + this.config.nonceStateSeparator + state;
            }
            else {
                state = nonce_1;
            }
        }

	// ...

        if (nonce && this.oidc) {
            url += '&nonce=' + encodeURIComponent(nonce);
        }
```

and therefore was never attached to the login url (and in my case was later missing in the identity token, and it couldn't be verified)